### PR TITLE
Fancy non-whitespace indentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,9 +156,7 @@ pub mod notation_constructors;
 
 pub use geometry::{Col, Height, Pos, Row, Size, Width};
 pub use notation::Notation;
-pub use pretty_printing::{
-    pretty_print, pretty_print_to_string, Indentation, Line, PrettyDoc, Segment,
-};
+pub use pretty_printing::{pretty_print, pretty_print_to_string, Line, PrettyDoc, Segment};
 pub use valid_notation::{NotationError, ValidNotation};
 
 pub mod testing {

--- a/src/notation.rs
+++ b/src/notation.rs
@@ -14,6 +14,7 @@ use std::ops::{Add, BitOr, BitXor, Shr};
 pub enum Notation<S> {
     /// Display nothing.
     Empty,
+    // TODO update doc
     /// Display a newline followed a number of spaces determined by the indentation level. (See
     /// [`Notation::Indent`]).
     Newline,
@@ -26,10 +27,11 @@ pub enum Notation<S> {
     /// followed the recommendation of not putting `Newline`s in the left-most options of choices,
     /// then this `Flat` will be displayed all on one line.
     Flat(Box<Notation<S>>),
+    // TODO update doc
     /// Increase the indentation level of the contained notation by the given width. The
     /// indentation level determines the number of spaces put after `Newline`s. (It therefore
     /// doesn't affect the first line of a notation.)
-    Indent(Width, Box<Notation<S>>),
+    Indent(Literal<S>, Box<Notation<S>>),
     /// Display both notations. The first character of the right notation immediately follows the
     /// last character of the left notation. Note that the column at which the right notation
     /// starts does not affect its indentation level.
@@ -112,7 +114,7 @@ impl<S> fmt::Display for Notation<S> {
             Text(_) => write!(f, "TEXT"),
             Literal(lit) => write!(f, "'{}'", lit.string),
             Flat(note) => write!(f, "Flat({})", note),
-            Indent(i, note) => write!(f, "{}⇒({})", i, note),
+            Indent(lit, note) => write!(f, "'{}'⇒({})", lit.string, note),
             Concat(left, right) => write!(f, "{} + {}", left, right),
             Choice(opt1, opt2) => write!(f, "({} | {})", opt1, opt2),
             IfEmptyText(opt1, opt2) => write!(f, "IfEmptyText({} | {})", opt1, opt2),
@@ -155,13 +157,19 @@ impl<S> BitXor<Notation<S>> for Notation<S> {
     }
 }
 
-impl<S> Shr<Notation<S>> for Width {
+impl<S> Shr<Notation<S>> for Width
+where
+    S: Default,
+{
     type Output = Notation<S>;
 
-    /// `i >> x` is shorthand for `Indent(i, Newline + x)` (sometimes called "nesting").
+    /// `i >> x` is shorthand for `Indent(i_spaces, Newline + x)` (sometimes called "nesting").
     fn shr(self, notation: Notation<S>) -> Notation<S> {
         Notation::Indent(
-            self,
+            Literal::new(
+                &format!("{:spaces$}", "", spaces = self as usize),
+                S::default(),
+            ),
             Box::new(Notation::Concat(
                 Box::new(Notation::Newline),
                 Box::new(notation),

--- a/src/notation.rs
+++ b/src/notation.rs
@@ -14,9 +14,7 @@ use std::ops::{Add, BitOr, BitXor, Shr};
 pub enum Notation<S> {
     /// Display nothing.
     Empty,
-    // TODO update doc
-    /// Display a newline followed a number of spaces determined by the indentation level. (See
-    /// [`Notation::Indent`]).
+    /// Display a newline followed by the current indentation. (See [`Notation::Indent`]).
     Newline,
     /// Display a piece of text. Can only be used on a [`PrettyDoc`] node for which
     /// `.num_children()` returns `None` (implying that it contains text).
@@ -27,10 +25,12 @@ pub enum Notation<S> {
     /// followed the recommendation of not putting `Newline`s in the left-most options of choices,
     /// then this `Flat` will be displayed all on one line.
     Flat(Box<Notation<S>>),
-    // TODO update doc
-    /// Increase the indentation level of the contained notation by the given width. The
-    /// indentation level determines the number of spaces put after `Newline`s. (It therefore
-    /// doesn't affect the first line of a notation.)
+    /// Append a string to the indentation of the contained notation. All of the
+    /// indentation strings will be displayed after `Newline`s. (They therefore
+    /// don't affect the first line of a notation.) Indentation strings will
+    /// typically contain one indentation level's worth of whitespace characters
+    /// (eg. 4 spaces), but can be used for other purposes like placing comment
+    /// syntax at the start of a line.
     Indent(Literal<S>, Box<Notation<S>>),
     /// Display both notations. The first character of the right notation immediately follows the
     /// last character of the left notation. Note that the column at which the right notation

--- a/src/notation_constructors.rs
+++ b/src/notation_constructors.rs
@@ -1,6 +1,5 @@
 // TODO: docs
 
-use super::geometry::Width;
 use super::notation::{Literal, Notation};
 
 pub fn empty<S>() -> Notation<S> {
@@ -28,8 +27,9 @@ pub fn flat<S>(n: Notation<S>) -> Notation<S> {
     Notation::Flat(Box::new(n))
 }
 
-pub fn indent<S>(i: Width, n: Notation<S>) -> Notation<S> {
-    Notation::Indent(i, Box::new(n))
+pub fn indent<S>(s: &str, style: S, n: Notation<S>) -> Notation<S> {
+    let literal = Literal::new(s, style);
+    Notation::Indent(literal, Box::new(n))
 }
 
 pub fn mark<S>(mark_name: &'static str, n: Notation<S>) -> Notation<S> {

--- a/src/pane_printing/pane_print.rs
+++ b/src/pane_printing/pane_print.rs
@@ -284,18 +284,6 @@ where
         return Ok(());
     }
 
-    // Print indentation
-    for _ in 0..line.indentation.num_spaces {
-        if pos.col >= rect.max_col {
-            return Ok(());
-        }
-        let mark = line.indentation.mark;
-        window
-            .print_char(' ', pos, mark, &D::Style::default(), false)
-            .map_err(PaneError::PrettyWindowError)?;
-        pos.col += 1;
-    }
-
     // Print each segment
     for segment in line.segments {
         for ch in segment.str.chars() {

--- a/src/pretty_printing/mod.rs
+++ b/src/pretty_printing/mod.rs
@@ -3,7 +3,7 @@ mod oracle;
 mod pretty_doc;
 mod pretty_print;
 
-pub use consolidated_notation::PrintingError;
+pub use consolidated_notation::{PrintingError, Segment};
 pub use oracle::oracular_pretty_print;
 pub use pretty_doc::PrettyDoc;
-pub use pretty_print::{pretty_print, pretty_print_to_string, Indentation, Line, Segment};
+pub use pretty_print::{pretty_print, pretty_print_to_string, Line};

--- a/src/pretty_printing/oracle.rs
+++ b/src/pretty_printing/oracle.rs
@@ -11,7 +11,7 @@ const MAX_WIDTH: Width = 10_000;
 /// A list of lines; each line has (indentation, contents)
 ///
 /// **Invariant:** there's always at least one line
-struct Layout(Vec<(Width, String)>);
+struct Layout(Vec<String>);
 
 /// For testing!
 ///
@@ -46,19 +46,25 @@ fn pp<'d, D: PrettyDoc<'d>>(
     match note {
         Empty => Ok(prefix),
         Textual(textual) => Ok(prefix.append(Layout::text(textual.str))),
-        Newline(indent) => Ok(prefix.append(Layout::newline(indent))),
+        Newline(indent) => {
+            let mut indent_string = String::new();
+            for textual in indent {
+                indent_string.push_str(textual.str);
+            }
+            Ok(prefix.append(Layout::newline(indent_string)))
+        }
         Child(_, x) => pp(prefix, x.eval()?.0, suffix_len, width),
         Concat(x, y) => {
             let x = x.eval()?.0;
             let y = y.eval()?.0;
-            let x_suffix_len = first_line_len(y, suffix_len)?.min(MAX_WIDTH);
+            let x_suffix_len = first_line_len(y.clone(), suffix_len)?.min(MAX_WIDTH);
             let y_prefix = pp(prefix, x, x_suffix_len, width)?;
             pp(y_prefix, y, suffix_len, width)
         }
         Choice(x, y) => {
             let x = x.eval()?.0;
             let last_len = prefix.last_line_len();
-            let first_len = first_line_len(x, suffix_len)?;
+            let first_len = first_line_len(x.clone(), suffix_len)?;
             let fits = last_len + first_len <= width;
             if DEBUG_PRINT {
                 println!(
@@ -100,17 +106,15 @@ fn first_line_len<'d, D: PrettyDoc<'d>>(
 
 impl Layout {
     fn empty() -> Layout {
-        Layout(vec![(0, String::new())])
+        Layout(vec![String::new()])
     }
 
     fn text(s: &str) -> Layout {
-        Layout(vec![(0, s.to_string())])
+        Layout(vec![s.to_string()])
     }
 
-    fn newline(indent: Width) -> Layout {
-        let first_line = (0, String::new());
-        let second_line = (indent, String::new());
-        Layout(vec![first_line, second_line])
+    fn newline(prefix: String) -> Layout {
+        Layout(vec![String::new(), prefix])
     }
 
     fn append(self, other: Layout) -> Layout {
@@ -119,8 +123,8 @@ impl Layout {
 
         // Then the last line of `self` extended by the first line of `other`
         let mut other_lines = other.0.into_iter();
-        let suffix = other_lines.next().unwrap().1; // relies on invariant
-        lines.last_mut().unwrap().1.push_str(&suffix); // relies on invariant
+        let suffix = other_lines.next().unwrap(); // relies on invariant
+        lines.last_mut().unwrap().push_str(&suffix); // relies on invariant
 
         // Then the rest of the lines of `other`
         for line in other_lines {
@@ -132,17 +136,17 @@ impl Layout {
 
     fn last_line_len(&self) -> Width {
         let last_line = self.0.last().unwrap(); // relies on invariant
-        last_line.0 + str_width(&last_line.1)
+        str_width(&last_line)
     }
 }
 
 impl fmt::Display for Layout {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for (i, (spaces, line)) in self.0.iter().enumerate() {
+        for (i, line) in self.0.iter().enumerate() {
             if i > 0 {
                 writeln!(f)?;
             }
-            write!(f, "{:spaces$}{}", "", line, spaces = *spaces as usize)?;
+            write!(f, "{}", line)?;
         }
         Ok(())
     }
@@ -150,14 +154,14 @@ impl fmt::Display for Layout {
 
 #[test]
 fn test_layout() {
-    let ab = Layout(vec![(1, "a".to_owned()), (1, "bb".to_owned())]);
-    let cd = Layout(vec![(2, "ccc".to_owned()), (2, "dddd".to_owned())]);
+    let ab = Layout(vec![" a".to_owned(), " bb".to_owned()]);
+    let cd = Layout(vec!["ccc".to_owned(), "  dddd".to_owned()]);
     let abcd = ab.append(cd);
     assert_eq!(format!("{}", abcd), " a\n bbccc\n  dddd");
 
     let hello = Layout::text("Hello");
     let world = Layout::text("world!");
-    let newline = Layout::newline(2);
+    let newline = Layout::newline("  ".to_owned());
     let hello_world = hello.append(newline).append(world);
     assert_eq!(format!("{}", hello_world), "Hello\n  world!");
 }

--- a/src/pretty_printing/oracle.rs
+++ b/src/pretty_printing/oracle.rs
@@ -8,7 +8,7 @@ use std::fmt;
 const DEBUG_PRINT: bool = false;
 const MAX_WIDTH: Width = 10_000;
 
-/// A list of lines; each line has (indentation, contents)
+/// A list of lines.
 ///
 /// **Invariant:** there's always at least one line
 struct Layout(Vec<String>);

--- a/src/pretty_printing/oracle.rs
+++ b/src/pretty_printing/oracle.rs
@@ -47,11 +47,14 @@ fn pp<'d, D: PrettyDoc<'d>>(
         Empty => Ok(prefix),
         Textual(textual) => Ok(prefix.append(Layout::text(textual.str))),
         Newline(indent) => {
-            let mut indent_string = String::new();
-            for textual in indent {
-                indent_string.push_str(textual.str);
+            let mut indent = &indent;
+            let mut indent_strings = Vec::new();
+            while let Some(indent_node) = indent {
+                indent_strings.push(indent_node.segment.str.to_owned());
+                indent = &indent_node.parent;
             }
-            Ok(prefix.append(Layout::newline(indent_string)))
+            indent_strings.reverse();
+            Ok(prefix.append(Layout::newline(indent_strings.join(""))))
         }
         Child(_, x) => pp(prefix, x.eval()?.0, suffix_len, width),
         Concat(x, y) => {

--- a/src/pretty_printing/pretty_print.rs
+++ b/src/pretty_printing/pretty_print.rs
@@ -108,18 +108,16 @@ impl<'d, D: PrettyDoc<'d>> Chunk<'d, D> {
     }
 }
 
-// TODO: Update docs
 /// The contents of a single pretty printed line.
 pub struct Line<'d, D: PrettyDoc<'d>> {
-    /// A sequence of pieces of text to be displayed after `indentation`, in order from left to
+    /// A sequence of pieces of text to be displayed in order from left to
     /// right, with no spacing in between.
     pub segments: Vec<Segment<'d, D>>,
 }
 
-// TODO: Update docs
 /// The contents of the line containing the focus point.
 pub struct FocusedLine<'d, D: PrettyDoc<'d>> {
-    /// Pieces of text that appear after the indentation but before the focus point.
+    /// Pieces of text that appear before the focus point.
     pub left_segments: Vec<Segment<'d, D>>,
     /// Pieces of text that appear after the focus point.
     pub right_segments: Vec<Segment<'d, D>>,
@@ -186,16 +184,12 @@ impl<'d, D: PrettyDoc<'d>> ToString for FocusedLine<'d, D> {
     }
 }
 
-// TODO: Update docs
-// | segments ->|<- chunks |
-// ^^^^^^^^^^^^^^
-//   prefix_len
 /// INVARIANTS:
 /// - prefix_len is always sum(segment width)
 /// - chunks only contains Textual, Choice, Child
 ///
-/// | indentation | segments ->|<- chunks |
-/// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/// | segments ->|<- chunks |
+/// ^^^^^^^^^^^^^^
 ///   prefix_len
 struct Block<'d, D: PrettyDoc<'d>> {
     /// Resolved text. Last element is the rightmost text.
@@ -444,7 +438,7 @@ impl<'d, D: PrettyDoc<'d>> Printer<'d, D> {
         use ConsolidatedNotation::*;
         span!("expand_first");
 
-        // | block.indent | block.segments ->| stack ->|<- block.chunks |
+        // | block.segments ->| stack ->|<- block.chunks |
         let mut stack = vec![chunk];
         while let Some(chunk) = stack.pop() {
             match chunk.notation {
@@ -477,7 +471,7 @@ impl<'d, D: PrettyDoc<'d>> Printer<'d, D> {
         use ConsolidatedNotation::*;
         span!("expand_last");
 
-        // | block.indent | block.segments ->| chunks ->|<- stack |<- block.chunks |
+        // | block.segments ->| chunks ->|<- stack |<- block.chunks |
         let mut chunks = Vec::new();
         let mut stack = vec![chunk];
         while let Some(chunk) = stack.pop() {

--- a/tests/standard/test_cases/basics.rs
+++ b/tests/standard/test_cases/basics.rs
@@ -1,5 +1,5 @@
 use crate::standard::pretty_testing::{all_paths, assert_pp, punct, SimpleDoc};
-use partial_pretty_printer::notation_constructors::{empty, flat, nl};
+use partial_pretty_printer::notation_constructors::{empty, flat, indent, nl};
 
 #[test]
 fn basics_empty() {
@@ -29,6 +29,12 @@ fn basics_newline() {
 fn basics_indent() {
     let notation = punct("Hello") + (2 >> punct("world!"));
     assert_pp(&SimpleDoc::new(notation), 80, &["Hello", "  world!"]);
+}
+
+#[test]
+fn basics_non_whitespace_indent() {
+    let notation = punct("Hello") + indent("// ", (), nl() + punct("world!"));
+    assert_pp(&SimpleDoc::new(notation), 80, &["Hello", "// world!"]);
 }
 
 #[test]

--- a/tests/standard/test_cases/marks.rs
+++ b/tests/standard/test_cases/marks.rs
@@ -63,14 +63,6 @@ impl RichText {
 
     fn push_line<'d>(&mut self, line: Line<'d, &'d Json>) {
         let mut chars = Vec::new();
-        for _ in 0..line.indentation.num_spaces {
-            chars.push(RichChar {
-                ch: ' ',
-                id: line.indentation.doc_id,
-                style: BasicStyle::default(),
-                mark: line.indentation.mark.copied(),
-            });
-        }
         for segment in &line.segments {
             for ch in segment.str.chars() {
                 chars.push(RichChar {
@@ -193,10 +185,10 @@ fn test_json_marks() {
             r#"ggggaaaaabb22g"#,
             r#"ggggccccccdd33g"#,
             r#"ggggeeeeeeeeeeeff7"#,
-            r#"77777777444444444447"#,
-            r#"7777777755555557"#,
-            r#"7777777766666666"#,
-            r#"77777"#,
+            r#"gggg7777444444444447"#,
+            r#"gggg777755555557"#,
+            r#"gggg777766666666"#,
+            r#"gggg7"#,
             r#"g"#,
         ]
         .join("\n"),
@@ -227,10 +219,10 @@ fn test_json_marks() {
             r#"              "#,
             r#"               "#,
             r#"                 ["#,
-            r#"FFFFFFFFFFFFFFFFFFFF"#,
-            r#"FFFFFFFFLLLLLLLF"#,
-            r#"FFFFFFFFFFFFFFFF"#,
-            r#"FFFF]"#,
+            r#"    FFFFFFFFFFFFFFFF"#,
+            r#"    FFFFLLLLLLLF"#,
+            r#"    FFFFFFFFFFFF"#,
+            r#"    ]"#,
             r#"}"#,
         ]
         .join("\n"),


### PR DESCRIPTION
Now indentation can be an arbitrary string instead of just a number of spaces. This will allow comment nodes to place comment syntax in front of all of the lines they contain. We also now store doc node ids and marks for each individual level of indentation, which will allow for better cursor region highlighting.