### PR TITLE
Make all PrettyDoc methods fallible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "partial-pretty-printer"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Justin Pombrio <zallambo@gmail.com>"]
 edition = "2018"
 

--- a/src/consolidated_notation.rs
+++ b/src/consolidated_notation.rs
@@ -186,8 +186,8 @@ pub enum PrintingError<E: std::error::Error + 'static> {
     NumChildrenChanged,
     #[error("Pretty printing encountered a Text or Literal after an EndOfLine.")]
     TextAfterEndOfLine,
-    #[error("PrettyDoc implementation error: {0}")]
-    PrettyDocImpl(#[from] E),
+    #[error("PrettyDoc error: {0}")]
+    PrettyDoc(#[from] E),
 }
 
 impl<'d, D: PrettyDoc<'d>> DelayedConsolidatedNotation<'d, D> {

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -23,6 +23,7 @@ struct Layout {
 /// testing of the more efficient but complex partial-pretty-printing algorithm.
 pub fn oracular_pretty_print<'d, D: PrettyDoc<'d>>(doc: D, width: Width) -> String {
     let note = DelayedConsolidatedNotation::new(doc)
+        .unwrap()
         .eval()
         .expect("Notation mismatch in oracle test (root)");
     let layout =
@@ -40,7 +41,7 @@ fn pp<'d, D: PrettyDoc<'d>>(
     suffix_len: Option<Width>,
     // The printing width
     width: Width,
-) -> Result<Layout, PrintingError> {
+) -> Result<Layout, PrintingError<D::Error>> {
     use ConsolidatedNotation::*;
 
     assert!(width < MAX_WIDTH);
@@ -106,7 +107,7 @@ fn pp<'d, D: PrettyDoc<'d>>(
 fn first_line_len<'d, D: PrettyDoc<'d>>(
     note: ConsolidatedNotation<'d, D>,
     suffix_len: Option<Width>,
-) -> Result<Option<Width>, PrintingError> {
+) -> Result<Option<Width>, PrintingError<D::Error>> {
     use ConsolidatedNotation::*;
 
     match note {

--- a/src/pretty_doc.rs
+++ b/src/pretty_doc.rs
@@ -23,39 +23,41 @@ pub trait PrettyDoc<'d>: Copy {
     /// Arbitrary property of a node that can be checked with
     /// [`PrettyDoc::condition()`]/[`Notation::Check`].
     type Condition: Condition + 'd;
+    /// An error that could occur when calling any of the trait methods.
+    type Error: std::error::Error + 'static;
 
     /// Get the id that uniquely identifies this node.
-    fn id(self) -> Self::Id;
+    fn id(self) -> Result<Self::Id, Self::Error>;
 
     /// Get this node's notation.
-    fn notation(self) -> &'d ValidNotation<Self::StyleLabel, Self::Condition>;
+    fn notation(self) -> Result<&'d ValidNotation<Self::StyleLabel, Self::Condition>, Self::Error>;
 
     /// Check whether the given condition holds for this node. The pretty printer will only call
     /// this method with conditions that were used in [`Notation::Check`].
-    fn condition(self, condition: &Self::Condition) -> bool;
+    fn condition(self, condition: &Self::Condition) -> Result<bool, Self::Error>;
 
     /// Get the style associated with this label, in the context of this node.
     /// The pretty printer will only call this method with labels that were used in
     /// [`Notation::Style`].
-    fn lookup_style(self, style_label: Self::StyleLabel) -> Self::Style;
+    fn lookup_style(self, style_label: Self::StyleLabel) -> Result<Self::Style, Self::Error>;
 
     /// Get the style to apply to this node. This method is called once per document node and applies
     /// to the whole node. It will be [`combined`](Style::combine) with any overlapping styles.
-    fn node_style(self) -> Self::Style;
+    fn node_style(self) -> Result<Self::Style, Self::Error>;
 
     /// Get the number of children this node has, or `None` if it contains text instead. `Some(0)` means
     /// that this node contains no children and no text.
-    fn num_children(self) -> Option<usize>;
+    fn num_children(self) -> Result<Option<usize>, Self::Error>;
 
     /// Get this node's text, or panic. The pretty printer will only call this method if
     /// [`num_children()`](PrettyDoc::num_children) returns `None` - it is ok to make this method
     /// panic otherwise.
-    fn unwrap_text(self) -> &'d str;
+    fn unwrap_text(self) -> Result<&'d str, Self::Error>;
 
     /// Get this node's i'th child, or panic. The pretty printer will only call this method if
     /// [`num_children()`](PrettyDoc::num_children) returns `Some(n)` for `n > i` - it is ok to make
     /// this method panic otherwise.
-    fn unwrap_child(self, i: usize) -> Self;
+    fn unwrap_child(self, i: usize) -> Result<Self, Self::Error>;
 
     /// Get this node's last child, or panic. The pretty printer will only call this method if
     /// [`num_children()`](PrettyDoc::num_children) returns `Some(n)` where `n > 0` - it is ok to
@@ -63,8 +65,8 @@ pub trait PrettyDoc<'d>: Copy {
     ///
     /// This method is redundant with [`unwrap_child()`](PrettyDoc::unwrap_child), but depending on
     /// your document representation it could have a more efficient implementation.
-    fn unwrap_last_child(self) -> Self {
-        match self.num_children() {
+    fn unwrap_last_child(self) -> Result<Self, Self::Error> {
+        match self.num_children()? {
             None => panic!("Bug in PrettyDoc impl: num_children's return value changed"),
             Some(n) => self.unwrap_child(n - 1),
         }
@@ -80,7 +82,7 @@ pub trait PrettyDoc<'d>: Copy {
     ///
     /// This method is redundant with [`unwrap_child()`](PrettyDoc::unwrap_child), but depending on
     /// your document representation it could have a more efficient implementation.
-    fn unwrap_prev_sibling(self, parent: Self, i: usize) -> Self {
+    fn unwrap_prev_sibling(self, parent: Self, i: usize) -> Result<Self, Self::Error> {
         parent.unwrap_child(i)
     }
 }

--- a/tests/standard/pretty_testing.rs
+++ b/tests/standard/pretty_testing.rs
@@ -26,36 +26,37 @@ impl<'a> PrettyDoc<'a> for &'a SimpleDoc {
     type Style = ();
     type StyleLabel = ();
     type Condition = ();
+    type Error = std::convert::Infallible;
 
-    fn id(self) -> usize {
-        0
+    fn id(self) -> Result<usize, Self::Error> {
+        Ok(0)
     }
 
-    fn notation(self) -> &'a ValidNotation<(), ()> {
-        &self.0
+    fn notation(self) -> Result<&'a ValidNotation<(), ()>, Self::Error> {
+        Ok(&self.0)
     }
 
-    fn condition(self, _condition: &()) -> bool {
-        false
+    fn condition(self, _condition: &()) -> Result<bool, Self::Error> {
+        Ok(false)
     }
 
-    fn node_style(self) -> () {
-        ()
+    fn node_style(self) -> Result<(), Self::Error> {
+        Ok(())
     }
 
-    fn lookup_style(self, _label: ()) -> () {
-        ()
+    fn lookup_style(self, _label: ()) -> Result<(), Self::Error> {
+        Ok(())
     }
 
-    fn num_children(self) -> Option<usize> {
-        Some(0)
+    fn num_children(self) -> Result<Option<usize>, Self::Error> {
+        Ok(Some(0))
     }
 
-    fn unwrap_text(self) -> &'a str {
+    fn unwrap_text(self) -> Result<&'a str, Self::Error> {
         panic!("Nothing in a simple doc");
     }
 
-    fn unwrap_child(self, _i: usize) -> Self {
+    fn unwrap_child(self, _i: usize) -> Result<Self, Self::Error> {
         panic!("Nothing in a simple doc");
     }
 }
@@ -94,9 +95,9 @@ fn print_above_and_below<'d, D: PrettyDoc<'d>>(
 pub fn all_paths<'d, D: PrettyDoc<'d>>(doc: D) -> Vec<Vec<usize>> {
     fn recur<'d, D: PrettyDoc<'d>>(doc: D, path: &mut Vec<usize>, paths: &mut Vec<Vec<usize>>) {
         paths.push(path.clone());
-        for i in 0..doc.num_children().unwrap_or(0) {
+        for i in 0..doc.num_children().unwrap().unwrap_or(0) {
             path.push(i);
-            recur(doc.unwrap_child(i), path, paths);
+            recur(doc.unwrap_child(i).unwrap(), path, paths);
             path.pop();
         }
     }
@@ -158,7 +159,7 @@ fn assert_pp_impl<'d, D: PrettyDoc<'d>>(doc: D, width: Width, expected_lines: Op
             &format!(
                 "IN PRETTY PRINTING WITH WIDTH {}\nNOTATION\n{}",
                 width,
-                doc.notation()
+                doc.notation().unwrap()
             ),
             ("ORACLE", oracle_result.clone()),
             ("ACTUAL", lines.join("\n")),

--- a/tests/standard/test_cases/flow_wrap.rs
+++ b/tests/standard/test_cases/flow_wrap.rs
@@ -62,52 +62,53 @@ impl<'d> PrettyDoc<'d> for &'d FlowWrap {
     type Style = ();
     type StyleLabel = ();
     type Condition = ();
+    type Error = std::convert::Infallible;
 
-    fn id(self) -> usize {
-        self.id
+    fn id(self) -> Result<usize, Self::Error> {
+        Ok(self.id)
     }
 
-    fn notation(self) -> &'d ValidNotation<(), ()> {
+    fn notation(self) -> Result<&'d ValidNotation<(), ()>, Self::Error> {
         use FlowWrapData::*;
 
-        match &self.data {
+        Ok(match &self.data {
             Word(_) => &WORD_NOTATION,
             Words(_) => &WORDS_NOTATION,
             Paragraph(_) => &PARAGRAPH_NOTATION,
-        }
+        })
     }
 
-    fn condition(self, _condition: &()) -> bool {
-        false
+    fn condition(self, _condition: &()) -> Result<bool, Self::Error> {
+        Ok(false)
     }
 
-    fn node_style(self) -> () {
-        ()
+    fn node_style(self) -> Result<(), Self::Error> {
+        Ok(())
     }
 
-    fn lookup_style(self, _label: ()) -> () {
-        ()
+    fn lookup_style(self, _label: ()) -> Result<(), Self::Error> {
+        Ok(())
     }
 
-    fn num_children(self) -> Option<usize> {
-        match self.contents() {
+    fn num_children(self) -> Result<Option<usize>, Self::Error> {
+        Ok(match self.contents() {
             Contents::Text(_) => None,
             Contents::Children(slice) => Some(slice.len()),
-        }
+        })
     }
 
-    fn unwrap_text(self) -> &'d str {
-        match self.contents() {
+    fn unwrap_text(self) -> Result<&'d str, Self::Error> {
+        Ok(match self.contents() {
             Contents::Text(txt) => txt,
             Contents::Children(_) => unreachable!(),
-        }
+        })
     }
 
-    fn unwrap_child(self, i: usize) -> Self {
-        match self.contents() {
+    fn unwrap_child(self, i: usize) -> Result<Self, Self::Error> {
+        Ok(match self.contents() {
             Contents::Text(_) => unreachable!(),
             Contents::Children(slice) => &slice[i],
-        }
+        })
     }
 }
 

--- a/tests/standard/test_cases/iter_chain.rs
+++ b/tests/standard/test_cases/iter_chain.rs
@@ -73,53 +73,54 @@ impl<'d> PrettyDoc<'d> for &'d IterChain {
     type Style = ();
     type StyleLabel = ();
     type Condition = ();
+    type Error = std::convert::Infallible;
 
-    fn id(self) -> usize {
-        self.id
+    fn id(self) -> Result<usize, Self::Error> {
+        Ok(self.id)
     }
 
-    fn notation(self) -> &'d ValidNotation<(), ()> {
+    fn notation(self) -> Result<&'d ValidNotation<(), ()>, Self::Error> {
         use IterChainData::*;
 
-        match self.data {
+        Ok(match self.data {
             Var(_) => &VAR_NOTATION,
             MethodCall(_) => &METHOD_CALL_NOTATION,
             Closure(_) => &CLOSURE_NOTATION,
             Times(_) => &TIMES_NOTATION,
-        }
+        })
     }
 
-    fn condition(self, _condition: &()) -> bool {
-        false
+    fn condition(self, _condition: &()) -> Result<bool, Self::Error> {
+        Ok(false)
     }
 
-    fn node_style(self) -> () {
-        ()
+    fn node_style(self) -> Result<(), Self::Error> {
+        Ok(())
     }
 
-    fn lookup_style(self, _label: ()) -> () {
-        ()
+    fn lookup_style(self, _label: ()) -> Result<(), Self::Error> {
+        Ok(())
     }
 
-    fn num_children(self) -> Option<usize> {
-        match self.contents() {
+    fn num_children(self) -> Result<Option<usize>, Self::Error> {
+        Ok(match self.contents() {
             Contents::Text(_) => None,
             Contents::Children(slice) => Some(slice.len()),
-        }
+        })
     }
 
-    fn unwrap_text(self) -> &'d str {
-        match self.contents() {
+    fn unwrap_text(self) -> Result<&'d str, Self::Error> {
+        Ok(match self.contents() {
             Contents::Text(txt) => txt,
             Contents::Children(_) => unreachable!(),
-        }
+        })
     }
 
-    fn unwrap_child(self, i: usize) -> Self {
-        match self.contents() {
+    fn unwrap_child(self, i: usize) -> Result<Self, Self::Error> {
+        Ok(match self.contents() {
             Contents::Text(_) => unreachable!(),
             Contents::Children(slice) => &slice[i],
-        }
+        })
     }
 }
 

--- a/tests/standard/test_cases/ruby_loop.rs
+++ b/tests/standard/test_cases/ruby_loop.rs
@@ -55,52 +55,53 @@ impl<'d> PrettyDoc<'d> for &'d Ruby {
     type Style = ();
     type StyleLabel = ();
     type Condition = ();
+    type Error = std::convert::Infallible;
 
-    fn id(self) -> usize {
-        self.id
+    fn id(self) -> Result<usize, Self::Error> {
+        Ok(self.id)
     }
 
-    fn notation(self) -> &'d ValidNotation<(), ()> {
+    fn notation(self) -> Result<&'d ValidNotation<(), ()>, Self::Error> {
         use RubyData::*;
 
-        match self.data {
+        Ok(match self.data {
             Var(_) => &VAR_NOTATION,
             MethodCall(_) => &METHOD_CALL_NOTATION,
             DoLoop(_) => &DO_LOOP_NOTATION,
-        }
+        })
     }
 
-    fn condition(self, _condition: &()) -> bool {
-        false
+    fn condition(self, _condition: &()) -> Result<bool, Self::Error> {
+        Ok(false)
     }
 
-    fn node_style(self) -> () {
-        ()
+    fn node_style(self) -> Result<(), Self::Error> {
+        Ok(())
     }
 
-    fn lookup_style(self, _label: ()) -> () {
-        ()
+    fn lookup_style(self, _label: ()) -> Result<(), Self::Error> {
+        Ok(())
     }
 
-    fn num_children(self) -> Option<usize> {
-        match self.contents() {
+    fn num_children(self) -> Result<Option<usize>, Self::Error> {
+        Ok(match self.contents() {
             Contents::Text(_) => None,
             Contents::Children(slice) => Some(slice.len()),
-        }
+        })
     }
 
-    fn unwrap_text(self) -> &'d str {
-        match self.contents() {
+    fn unwrap_text(self) -> Result<&'d str, Self::Error> {
+        Ok(match self.contents() {
             Contents::Text(txt) => txt,
             Contents::Children(_) => unreachable!(),
-        }
+        })
     }
 
-    fn unwrap_child(self, i: usize) -> Self {
-        match self.contents() {
+    fn unwrap_child(self, i: usize) -> Result<Self, Self::Error> {
+        Ok(match self.contents() {
             Contents::Text(_) => unreachable!(),
             Contents::Children(slice) => &slice[i],
-        }
+        })
     }
 }
 


### PR DESCRIPTION
Synless might fail to find a notation for a `PrettyDoc` node, so let's just make all the trait methods return `Result`.